### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Go Test
 
+permissions:
+  contents: read
+
 on: [push]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/ls1intum/git-container/security/code-scanning/1](https://github.com/ls1intum/git-container/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimum required permissions for the workflow to function. In this case:
- The `contents: read` permission is needed for the `actions/checkout@v4` step to clone the repository.
- No other permissions are explicitly required by the workflow.

This `permissions` block will ensure that the workflow operates with the least privilege, mitigating potential security risks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
