### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build Docker Images
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ls1intum/git-container/security/code-scanning/2](https://github.com/ls1intum/git-container/security/code-scanning/2)

To fix the problem, we will add a `permissions` block to the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Since the workflow involves building Docker images and pushing them to a repository, the `contents: read` and possibly other minimal permissions (e.g., `packages: write` for Docker image pushes) will be explicitly set. The fix ensures that unnecessary permissions are not granted, reducing the risk of misuse.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
